### PR TITLE
Move clear exception

### DIFF
--- a/lib/quarantine.rb
+++ b/lib/quarantine.rb
@@ -122,6 +122,9 @@ class Quarantine
   def on_test(example, status, passed:)
     extra_attributes = @options[:extra_attributes] ? @options[:extra_attributes].call(example) : {}
 
+    # Clear exception after looking at extra_attributes, as caller may want to view exception data
+    example.clear_exception! if status == :quarantined && !passed
+
     new_consecutive_passes = passed ? (@old_tests[example.id]&.consecutive_passes || 0) + 1 : 0
     release_at = @options[:release_at_consecutive_passes]
     new_status = !release_at.nil? && new_consecutive_passes >= release_at ? :passing : status

--- a/lib/quarantine/rspec_adapter.rb
+++ b/lib/quarantine/rspec_adapter.rb
@@ -108,7 +108,6 @@ class Quarantine
           result = Quarantine::RSpecAdapter.final_status(example)
           if result
             status, passed = result
-            example.clear_exception! if status == :quarantined && !passed
             Quarantine::RSpecAdapter.quarantine.on_test(example, status, passed: passed)
           end
         end


### PR DESCRIPTION
Want to know why the spec failed, so would like to be able to access the failing exception within the extra_attributes hook. Move the clear_exception! after calling extra_attributes